### PR TITLE
Beta v0.5.0

### DIFF
--- a/extensions/livestream-defaults.json
+++ b/extensions/livestream-defaults.json
@@ -1,0 +1,27 @@
+{
+    "shared": {
+        "gopSize": "1",
+        "gopPerSegment": "2",
+        "segsPerPlist": "3",
+        "bucket": "exampleproj-20181220152035-deployment"
+    },
+    "mediaLive": {
+        "securityGroup": "0.0.0.0/0",
+        "ingestType": "RTMP_PUSH",
+        "encodingProfile": "FULL",
+        "autoStart": "YES"
+    },
+    "mediaPackage": {
+        "endpoints": "HLS,DASH",
+        "startOverWindow": "86400"
+    },
+    "mediaStorage": {
+        "storageType": "mStore"
+    },
+    "cloudFront": {
+        "enableDistrubtion": "YES",
+        "priceClass": "PriceClass_100",
+        "sBucketLogs": "",
+        "sLogPrefix": "cf_logs/"
+    }
+}

--- a/extensions/livestream-questions.json
+++ b/extensions/livestream-questions.json
@@ -2,7 +2,7 @@
     "Elemental": {
         "inputs": [
             {
-                "key": "resourceName",
+                "key": "name",
                 "question": "Provide a friendly name for your resource to be used as a label for this category in the project:",
                 "validation": {
                     "operator": "regex",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amplify-elemental-plugin",
+  "name": "amplify-category-video",
   "version": "1.0.0",
   "description": "Plugin for Amplify to add support for live streaming. Made for Unicorn Trivia Workshop",
   "main": "index.js",
@@ -13,6 +13,7 @@
     "fs-extra": "^7.0.0",
     "ini": "^1.3.5",
     "inquirer": "^6.2.0",
-    "mime-types": "^2.1.21"
+    "mime-types": "^2.1.21",
+    "sha1": "^1.1.1"
   }
 }


### PR DESCRIPTION
Initial plugin to create the elemental resources to host a AWS Video Services

- Added json file exporting so you can backup your configuration
- Added sha1 checks to the json file to make sure people don't push the same configuration
- Fixed Amplify categories not seeing the plugin.
- Fixed Amplify verb swap so now you can call either `amplify add video` or `amplify video add`
- Added defaults file
- Update now uses last known values from the last push (this can be used to import an existing confige on update more to come here)
- NOTE: Update is broken until this is pulled in: https://github.com/aws-amplify/amplify-cli/pull/650

Please note this uses lambda functions to deploy the resources as there is no cloudformation support for elemental yet.